### PR TITLE
[FIX] 채팅방 팝업 메뉴 포커싱 이슈(enter, space 입력시 계속 이벤트 발생)

### DIFF
--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -473,9 +473,12 @@ export class ChatGateway
 			&& channel._users.has(user_heritor)) {
 			channel._users.get(user_heritor)._is_muted = true;
 			setTimeout(() => {
-				channel._users.get(user_heritor)._is_muted = false;
-				this.ft_chat_refresh_all(channel);
-			}, 30000);
+				if (channel._users.get(user_heritor))
+				{
+					channel._users.get(user_heritor)._is_muted = false;
+					this.ft_chat_refresh_all(channel);
+				}
+			}, 3000);
 			return (0);
 		}
 		return (1)

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -478,7 +478,7 @@ export class ChatGateway
 					channel._users.get(user_heritor)._is_muted = false;
 					this.ft_chat_refresh_all(channel);
 				}
-			}, 3000);
+			}, 30000);
 			return (0);
 		}
 		return (1)

--- a/frontend/src/components/Auth/UserLayout.svelte
+++ b/frontend/src/components/Auth/UserLayout.svelte
@@ -51,7 +51,6 @@
       friendList = await getApi({
             path: 'friends/',
         });
-      console.log("done");
     }
   };
 

--- a/frontend/src/components/Chat/ChatUserOptions.svelte
+++ b/frontend/src/components/Chat/ChatUserOptions.svelte
@@ -18,6 +18,10 @@
 
 	let chat_socket: Socket;
 	let game_socket: Socket;
+	// let optionButtonElement: HTMLButtonElement;
+	let optionButtonElements: Array<HTMLButtonElement | null> = [null, null, null, null, null]; // Initialize the array with null values
+
+	// $: optionButtonElement;
 
 	const chatUnsubscribe: Unsubscriber = socketStore.subscribe((_socket: Socket) => {
 		chat_socket = _socket;
@@ -99,7 +103,12 @@
 	<div class="hover:variant-filled-surface">
 		<button
 			class="cursor-pointer"
-			on:click={() => {ft_profile_view_in_chatroom(chatUser._user_info)}}
+			bind:this={optionButtonElements[0]}
+			on:click={() => {
+					optionButtonElements[0]?.blur();
+					ft_profile_view_in_chatroom(chatUser._user_info);
+				}
+			}
 		>
 			개인정보
 		</button>
@@ -109,7 +118,9 @@
 		<div class="hover:variant-filled-surface">
 			<button
 				class="cursor-pointer"
+				bind:this={optionButtonElements[1]}
 				on:click={() => {
+					optionButtonElements[1]?.blur();
 					ft_invite_user('invite');
 				}}>놀이 초대</button
 			>
@@ -119,7 +130,9 @@
 				<div class="hover:variant-filled-surface">
 					<button
 						class="cursor-pointer"
+						bind:this={optionButtonElements[2]}
 						on:click={() => {
+							optionButtonElements[2]?.blur();
 							ft_mute_user('mute');
 						}}>멈춰✋</button
 					>
@@ -128,7 +141,9 @@
 			<div class="hover:variant-filled-surface">
 				<button
 					class="cursor-pointer"
+					bind:this={optionButtonElements[3]}
 					on:click={() => {
+						optionButtonElements[3]?.blur();
 						ft_kick_user('kick');
 					}}>내보내기</button
 				>
@@ -136,7 +151,9 @@
 			<div class="hover:variant-filled-surface">
 				<button
 					class="cursor-pointer"
+					bind:this={optionButtonElements[4]}
 					on:click={() => {
+						optionButtonElements[4]?.blur();
 						ft_ban_user('ban');
 					}}>영구추방</button
 				>

--- a/frontend/src/components/Chat/DmChatUI.svelte
+++ b/frontend/src/components/Chat/DmChatUI.svelte
@@ -68,7 +68,8 @@
     let elemChat: HTMLElement
     
     function scrollChatBottom(behavior?: ScrollBehavior): void {
-        elemChat.scrollTo({ top: elemChat.scrollHeight, behavior })
+        if (elemChat.scrollHeight)
+            elemChat.scrollTo({ top: elemChat.scrollHeight, behavior })
     }
 
     async function addMessage(): Promise<void> {

--- a/frontend/src/components/Chat/DmList.svelte
+++ b/frontend/src/components/Chat/DmList.svelte
@@ -95,7 +95,6 @@
     <header class="card-footer  top-0 w-full">
       <div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
         <input type="search" placeholder="Search!!" bind:value={opponentUserId} on:keydown={ftDmSearchKeyDown} />
-        <button type="button" class="variant-filled-surface" on:click={ftDmSearch}>Add</button>
       </div>
     </header>
     <!-- DM list -->

--- a/frontend/src/routes/main/[chat_room]/+page.svelte
+++ b/frontend/src/routes/main/[chat_room]/+page.svelte
@@ -172,7 +172,8 @@
 	let elemChat: HTMLElement;
 
 	function scrollChatBottom(behavior?: ScrollBehavior): void {
-		elemChat.scrollTo({ top: elemChat.scrollHeight, behavior });
+		if (elemChat.scrollHeight)
+			elemChat.scrollTo({ top: elemChat.scrollHeight, behavior });
 	}
 
 </script>


### PR DESCRIPTION
- 채팅방에서 팝업 메뉴 선택 이후에서 html 태그 포커싱이 남아 있어서 enter, space 키 입력시 on:click 이벤트 발생하던 것 
선택된 이후로는 blur처리하여 포커싱 벗어나게 처리
   하지만 왜 포커싱이 남아있었는지와 더 깔끔한 방법은 없는지, 지금은 처리한 방법이 해결책은 아닌 우회책인지에 대해 추가 확인이 필요
- DM tab list serach 영역에서 button 제거
- scroll bar error는 발생할떄있고 아닐 떄가 있을때 여러 환경에서 보아야 더 정확할 것으로 추정됨