### PR TITLE
feat: user block 과 friend delete 분리

### DIFF
--- a/backend/src/users/friend/friend.controller.ts
+++ b/backend/src/users/friend/friend.controller.ts
@@ -135,4 +135,21 @@ export class FriendsController {
   ): Promise<boolean> {
     return this.friendsService.blockUser(req.user, user_to);
   }
+
+  // Unblock a user
+  @ApiOperation({
+    summary: '유저 block 해제 API',
+    description: 'user_to에 해당하는 유저의 block을 해제합니다.',
+  })
+  @ApiCreatedResponse({
+    description: '성공여부를 boolean값으로 반환해줍니다.',
+    type: Boolean,
+  })
+  @Delete('unblocks/:user_to')
+  unblockUser(
+    @Req() req: RequestWithUser,
+    @Param('user_to') user_to: string,
+  ): Promise<boolean> {
+    return this.friendsService.unBlockUser(req.user, user_to);
+  }
 }

--- a/backend/src/users/friend/friend.service.ts
+++ b/backend/src/users/friend/friend.service.ts
@@ -167,9 +167,7 @@ export class FriendsService {
       },
     });
 
-    if (blocked) {
-      throw new ForbiddenException('You are blocked by this user');
-    }
+    // 상호 block 허용
 
     const blockship: Friend = this.friendRepository.create({
       user_from: { id: user_from },
@@ -177,6 +175,23 @@ export class FriendsService {
       friend_status: FriendRequestStatus.BLOCKED,
     });
     await this.friendRepository.save(blockship);
+
+    return true;
+  }
+
+  async unBlockUser(user_from: string, user_to: string): Promise<boolean> {
+    // Fetch the friend entities from the database
+
+    const friendEntity: Friend = await this.friendRepository.findOne({
+      where: {
+        user_from: { id: user_from },
+        user_to: { id: user_to },
+        friend_status: FriendRequestStatus.BLOCKED,
+      },
+    });
+
+    // If found, remove(delete) the entity from the database
+    await this.friendRepository.delete(friendEntity);
 
     return true;
   }

--- a/frontend/src/components/Profile/UserProfile.svelte
+++ b/frontend/src/components/Profile/UserProfile.svelte
@@ -235,7 +235,7 @@
         else
         {
             try {
-            await delApi({ path: 'friends/' + profile_info.id , data:{
+            await delApi({ path: 'friends/unblocks' + profile_info.id , data:{
                 "user_to" : profile_info.id
             }
             });


### PR DESCRIPTION
block 해제 시 백엔드 api 를 friend delete 로 처리하고 있었어서,
서로 block 하는게 문제가 있어서
백엔드 friend delete 와 unblock 을 분리했습니다